### PR TITLE
Proposal for funnel axis

### DIFF
--- a/docs/pages/x/api/charts/funnel-plot.json
+++ b/docs/pages/x/api/charts/funnel-plot.json
@@ -1,6 +1,5 @@
 {
   "props": {
-    "gap": { "type": { "name": "number" }, "default": "0" },
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {

--- a/docs/translations/api-docs/charts/funnel-plot/funnel-plot.json
+++ b/docs/translations/api-docs/charts/funnel-plot/funnel-plot.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "gap": { "description": "The gap, in pixels, between funnel sections." },
     "onItemClick": {
       "description": "Callback fired when a funnel item is clicked.",
       "typeDescriptions": {

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -13,17 +13,13 @@ import { FunnelSectionLabel } from './FunnelSectionLabel';
 import {
   selectorChartXAxis,
   selectorChartYAxis,
+  selectorFunnelGap,
 } from './funnelAxisPlugin/useChartFunnelAxisRendering.selectors';
 import { isBandScale } from '@mui/x-charts/internals/isBandScale';
 
 cartesianSeriesTypes.addType('funnel');
 
 export interface FunnelPlotProps extends FunnelPlotSlotExtension {
-  /**
-   * The gap, in pixels, between funnel sections.
-   * @default 0
-   */
-  gap?: number;
   /**
    * Callback fired when a funnel item is clicked.
    * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
@@ -35,12 +31,12 @@ export interface FunnelPlotProps extends FunnelPlotSlotExtension {
   ) => void;
 }
 
-const useAggregatedData = (gapIn: number | undefined) => {
+const useAggregatedData = () => {
   const seriesData = useFunnelSeriesContext();
   const store = useStore();
   const { axis: xAxis, axisIds: xAxisIds } = useSelector(store, selectorChartXAxis);
   const { axis: yAxis, axisIds: yAxisIds } = useSelector(store, selectorChartYAxis);
-  const gap = gapIn ?? 0;
+  const gap = useSelector(store, selectorFunnelGap);
 
   const allData = React.useMemo(() => {
     if (seriesData === undefined) {
@@ -217,9 +213,9 @@ const useAggregatedData = (gapIn: number | undefined) => {
 };
 
 function FunnelPlot(props: FunnelPlotProps) {
-  const { onItemClick, gap, ...other } = props;
+  const { onItemClick, ...other } = props;
 
-  const data = useAggregatedData(gap);
+  const data = useAggregatedData();
 
   return (
     <React.Fragment>
@@ -264,11 +260,6 @@ FunnelPlot.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
   // ----------------------------------------------------------------------
-  /**
-   * The gap, in pixels, between funnel sections.
-   * @default 0
-   */
-  gap: PropTypes.number,
   /**
    * Callback fired when a funnel item is clicked.
    * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -84,7 +84,10 @@ const useAggregatedData = (gapIn: number | undefined) => {
           const position = xScale(bandIdentifier)!;
           return useBand ? position + bandWidth : position;
         }
-        return xScale(isHorizontal ? value + (stackOffset || 0) : value)!;
+        if (isHorizontal) {
+          return xScale(value + (stackOffset || 0))! + bandIndex * gap;
+        }
+        return xScale(value)!;
       };
 
       const yPosition = (
@@ -98,7 +101,10 @@ const useAggregatedData = (gapIn: number | undefined) => {
           const position = yScale(bandIdentifier);
           return useBand ? position! + bandWidth : position!;
         }
-        return yScale(isHorizontal ? value : value + (stackOffset || 0))!;
+        if (isHorizontal) {
+          return yScale(value)!;
+        }
+        return yScale(value + (stackOffset || 0))! + bandIndex * gap;
       };
 
       const allY = currentSeries.dataPoints.flatMap((d, dataIndex) =>
@@ -124,12 +130,12 @@ const useAggregatedData = (gapIn: number | undefined) => {
         ),
       );
       const minPoint = {
-        x: Math.min(...allX) + gap / 2,
-        y: Math.min(...allY) + gap / 2,
+        x: Math.min(...allX),
+        y: Math.min(...allY),
       };
       const maxPoint = {
-        x: Math.max(...allX) - gap / 2,
-        y: Math.max(...allY) - gap / 2,
+        x: Math.max(...allX),
+        y: Math.max(...allY),
       };
 
       return currentSeries.dataPoints.flatMap((values, dataIndex) => {

--- a/packages/x-charts-pro/src/FunnelChart/curves/bump.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/bump.ts
@@ -29,7 +29,7 @@ export class Bump implements CurveGenerator {
   ) {
     this.context = context;
     this.isHorizontal = isHorizontal ?? false;
-    this.gap = (gap ?? 0) / 2;
+    this.gap = gap ?? 0;
     this.min = min ?? { x: 0, y: 0 };
     this.max = max ?? { x: 0, y: 0 };
 
@@ -71,31 +71,17 @@ export class Bump implements CurveGenerator {
     const [p0, p1, p2, p3] = this.points;
 
     // 0 is the top-left corner
-    this.context.moveTo(p0.x + this.gap, p0.y);
-    this.context.lineTo(p0.x + this.gap, p0.y);
+    this.context.moveTo(p0.x, p0.y);
+    this.context.lineTo(p0.x, p0.y);
 
     // Bezier curve to point 1
-    this.context.bezierCurveTo(
-      (p0.x + p1.x) / 2,
-      p0.y,
-      (p0.x + p1.x) / 2,
-      p1.y,
-      p1.x - this.gap,
-      p1.y,
-    );
+    this.context.bezierCurveTo((p0.x + p1.x) / 2, p0.y, (p0.x + p1.x) / 2, p1.y, p1.x, p1.y);
 
     // Line to point 2
-    this.context.lineTo(p2.x - this.gap, p2.y);
+    this.context.lineTo(p2.x, p2.y);
 
     // Bezier curve back to point 3
-    this.context.bezierCurveTo(
-      (p2.x + p3.x) / 2,
-      p2.y,
-      (p2.x + p3.x) / 2,
-      p3.y,
-      p3.x + this.gap,
-      p3.y,
-    );
+    this.context.bezierCurveTo((p2.x + p3.x) / 2, p2.y, (p2.x + p3.x) / 2, p3.y, p3.x, p3.y);
 
     this.context.closePath();
   }
@@ -104,31 +90,17 @@ export class Bump implements CurveGenerator {
     const [p0, p1, p2, p3] = this.points;
 
     // 0 is the top-right corner
-    this.context.moveTo(p0.x, p0.y + this.gap);
-    this.context.lineTo(p0.x, p0.y + this.gap);
+    this.context.moveTo(p0.x, p0.y);
+    this.context.lineTo(p0.x, p0.y);
 
     // Bezier curve to point 1
-    this.context.bezierCurveTo(
-      p0.x,
-      (p0.y + p1.y) / 2,
-      p1.x,
-      (p0.y + p1.y) / 2,
-      p1.x,
-      p1.y - this.gap,
-    );
+    this.context.bezierCurveTo(p0.x, (p0.y + p1.y) / 2, p1.x, (p0.y + p1.y) / 2, p1.x, p1.y);
 
     // Line to point 2
-    this.context.lineTo(p2.x, p2.y - this.gap);
+    this.context.lineTo(p2.x, p2.y);
 
     // Bezier curve back to point 3
-    this.context.bezierCurveTo(
-      p2.x,
-      (p2.y + p3.y) / 2,
-      p3.x,
-      (p2.y + p3.y) / 2,
-      p3.x,
-      p3.y + this.gap,
-    );
+    this.context.bezierCurveTo(p2.x, (p2.y + p3.y) / 2, p3.x, (p2.y + p3.y) / 2, p3.x, p3.y);
 
     this.context.closePath();
   }

--- a/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
@@ -121,6 +121,28 @@ export class Linear implements CurveGenerator {
       return;
     }
 
+    // Add gaps where they are needed.
+    this.points = this.points.map((point, index) => {
+      const slopeStart = this.points.at(index <= 1 ? 0 : 3)!;
+      const slopeEnd = this.points.at(index <= 1 ? 1 : 2)!;
+
+      if (this.isHorizontal) {
+        const yGetter = lerpY(slopeStart.x - this.gap, slopeStart.y, slopeEnd.x, slopeEnd.y);
+
+        return {
+          x: point.x,
+          y: yGetter(point.x),
+        };
+      }
+
+      const xGetter = lerpX(slopeStart.x, slopeStart.y - this.gap, slopeEnd.x, slopeEnd.y);
+
+      return {
+        x: xGetter(point.y),
+        y: point.y,
+      };
+    });
+
     if (this.pointShape === 'sharp') {
       // In the last section, to form a triangle we need 3 points instead of 4
       // Else the algorithm will break.

--- a/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
@@ -7,7 +7,7 @@ import { lerpX, lerpY } from './utils';
 /**
  * This is a custom "linear" curve generator.
  * It draws straight lines for the 4 provided points,
- * with the option to add a gap between sections while also properly handling the border radius.
+ * with the option to properly handling the border radius.
  *
  * The implementation is based on the d3-shape linear curve generator.
  * https://github.com/d3/d3-shape/blob/a82254af78f08799c71d7ab25df557c4872a3c51/src/curve/linear.js
@@ -51,7 +51,7 @@ export class Linear implements CurveGenerator {
   ) {
     this.context = context;
     this.isHorizontal = isHorizontal ?? false;
-    this.gap = (gap ?? 0) / 2;
+    this.gap = gap ?? 0;
     this.position = position ?? 0;
     this.sections = sections ?? 1;
     this.borderRadius = borderRadius ?? 0;
@@ -121,38 +121,6 @@ export class Linear implements CurveGenerator {
       return;
     }
 
-    // Add gaps where they are needed.
-    this.points = this.points.map((point, index) => {
-      const slopeStart = this.points.at(index <= 1 ? 0 : 2)!;
-      const slopeEnd = this.points.at(index <= 1 ? 1 : 3)!;
-      if (this.isHorizontal) {
-        const yGetter = lerpY(
-          slopeStart.x - this.gap,
-          slopeStart.y,
-          slopeEnd.x - this.gap,
-          slopeEnd.y,
-        );
-        const xGap = point.x + (index === 0 || index === 3 ? this.gap : -this.gap);
-
-        return {
-          x: xGap,
-          y: yGetter(xGap),
-        };
-      }
-
-      const xGetter = lerpX(
-        slopeStart.x,
-        slopeStart.y - this.gap,
-        slopeEnd.x,
-        slopeEnd.y - this.gap,
-      );
-      const yGap = point.y + (index === 0 || index === 3 ? this.gap : -this.gap);
-      return {
-        x: xGetter(yGap),
-        y: yGap,
-      };
-    });
-
     if (this.pointShape === 'sharp') {
       // In the last section, to form a triangle we need 3 points instead of 4
       // Else the algorithm will break.
@@ -179,12 +147,8 @@ export class Linear implements CurveGenerator {
             ? { x: this.max.x, y: (this.max.y + this.min.y) / 2 }
             : { x: (this.max.x + this.min.x) / 2, y: this.max.y },
           // Then other points
-          this.isHorizontal
-            ? { x: firstPoint.x, y: firstPoint.y - this.gap / 2 }
-            : { x: firstPoint.x + this.gap / 2, y: firstPoint.y },
-          this.isHorizontal
-            ? { x: secondPoint.x, y: secondPoint.y + this.gap / 2 }
-            : { x: secondPoint.x - this.gap / 2, y: secondPoint.y },
+          firstPoint,
+          secondPoint,
         ];
       }
     }

--- a/packages/x-charts-pro/src/FunnelChart/curves/pyramid.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/pyramid.ts
@@ -97,7 +97,7 @@ export class Pyramid implements CurveGenerator {
       return;
     }
 
-    // Add gaps where they are needed.
+    // Replace funnel points by pyramids ones.
     this.points = this.points.map((point, index) => {
       if (this.isHorizontal) {
         const slopeEnd = {
@@ -112,7 +112,7 @@ export class Pyramid implements CurveGenerator {
                 y: this.max.y,
               };
         const yGetter = lerpY(slopeStart.x, slopeStart.y, slopeEnd.x, slopeEnd.y);
-        const xGap = point.x + (index === 0 || index === 3 ? this.gap : -this.gap);
+        const xGap = point.x;
 
         return {
           x: xGap,
@@ -132,7 +132,7 @@ export class Pyramid implements CurveGenerator {
             }
           : this.min;
       const xGetter = lerpX(slopeStart.x, slopeStart.y, slopeEnd.x, slopeEnd.y);
-      const yGap = point.y + (index === 0 || index === 3 ? this.gap : -this.gap);
+      const yGap = point.y;
       return {
         x: xGetter(yGap),
         y: yGap,

--- a/packages/x-charts-pro/src/FunnelChart/curves/step-pyramid.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/step-pyramid.ts
@@ -36,7 +36,7 @@ export class StepPyramid implements CurveGenerator {
   ) {
     this.context = context;
     this.isHorizontal = isHorizontal ?? false;
-    this.gap = (gap ?? 0) / 2;
+    this.gap = gap ?? 0;
     this.position = position ?? 0;
     this.sections = sections ?? 1;
     this.borderRadius = borderRadius ?? 0;
@@ -163,28 +163,26 @@ export class StepPyramid implements CurveGenerator {
       return;
     }
 
-    // Add gaps where they are needed.
+    // Replace funnel points by pyramids ones.
     this.points = this.points.map((point, index) => {
       const slopeStart = this.slopeStart(index);
       const slopeEnd = this.slopeEnd(index);
 
       if (this.isHorizontal) {
         const yGetter = lerpY(slopeStart.x, slopeStart.y, slopeEnd.x, slopeEnd.y);
-        const xGap = point.x + (index === 0 || index === 3 ? this.gap : -this.gap);
         const xInitial = this.initialX(index);
 
         return {
-          x: xGap,
+          x: point.x,
           y: yGetter(xInitial),
         };
       }
 
       const xGetter = lerpX(slopeStart.x, slopeStart.y, slopeEnd.x, slopeEnd.y);
-      const yGap = point.y + (index === 0 || index === 3 ? this.gap : -this.gap);
       const yInitial = this.initialY(index);
       return {
         x: xGetter(yInitial),
-        y: yGap,
+        y: point.y,
       };
     });
 

--- a/packages/x-charts-pro/src/FunnelChart/curves/step.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/step.ts
@@ -37,7 +37,7 @@ export class Step implements CurveGenerator {
   ) {
     this.context = context;
     this.isHorizontal = isHorizontal ?? false;
-    this.gap = (gap ?? 0) / 2;
+    this.gap = gap ?? 0;
     this.position = position ?? 0;
     this.sections = sections ?? 1;
     this.borderRadius = borderRadius ?? 0;
@@ -91,20 +91,6 @@ export class Step implements CurveGenerator {
       return {
         x: index <= 1 ? min(allX) : max(allX),
         y: index === 1 || index === 2 ? max(allY) : min(allY),
-      };
-    });
-
-    // Add gaps where they are needed.
-    this.points = this.points.map((point, index) => {
-      if (this.isHorizontal) {
-        return {
-          x: point.x + (index === 0 || index === 3 ? this.gap : -this.gap),
-          y: point.y,
-        };
-      }
-      return {
-        x: point.x,
-        y: point.y + (index === 0 || index === 3 ? this.gap : -this.gap),
       };
     });
 

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -171,3 +171,11 @@ export type FunnelLabelOptions = {
    */
   offset?: number | { x?: number; y?: number };
 };
+
+export type PositionGetter = (
+  value: number,
+  bandIndex: number,
+  bandIdentifier: string | number,
+  stackOffset?: number,
+  useBand?: boolean,
+) => number;

--- a/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/useChartFunnelAxisRendering.selectors.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/useChartFunnelAxisRendering.selectors.ts
@@ -10,8 +10,10 @@ import {
 import { computeAxisValue } from './computeAxisValue';
 import { UseChartFunnelAxisSignature } from './useChartFunnelAxis.types';
 
-export const selectorFunnelGap = (state: ChartState<[], [UseChartFunnelAxisSignature]>) =>
-  state.funnel?.gap ?? 0;
+export const selectorFunnel = (state: ChartState<[], [UseChartFunnelAxisSignature]>) =>
+  state.funnel;
+
+export const selectorFunnelGap = createSelector([selectorFunnel], (funnel) => funnel?.gap ?? 0);
 
 export const selectorChartXAxis = createSelector(
   [

--- a/packages/x-charts-pro/src/FunnelChart/labelUtils.ts
+++ b/packages/x-charts-pro/src/FunnelChart/labelUtils.ts
@@ -1,5 +1,5 @@
 import { Position } from '@mui/x-charts/models';
-import { FunnelDataPoints, FunnelLabelOptions } from './funnel.types';
+import { FunnelDataPoints, FunnelLabelOptions, PositionGetter } from './funnel.types';
 
 /**
  * It tries to keep the label inside the bounds of the section based on the position.
@@ -52,18 +52,8 @@ export const positionLabel = ({
   dataIndex,
   baseScaleData,
 }: Omit<FunnelLabelOptions, 'textAnchor' | 'dominantBaseline'> & {
-  xPosition: (
-    value: number,
-    bandIndex: number,
-    stackOffset?: number,
-    useBand?: boolean,
-  ) => number | undefined;
-  yPosition: (
-    value: number,
-    bandIndex: number,
-    stackOffset?: number,
-    useBand?: boolean,
-  ) => number | undefined;
+  xPosition: PositionGetter;
+  yPosition: PositionGetter;
   isHorizontal: boolean;
   values: readonly FunnelDataPoints[];
   dataIndex: number;
@@ -102,54 +92,79 @@ export const positionLabel = ({
     maxBottom = yPosition(values[3].y, baseScaleData[dataIndex], stackOffset)! + mv;
     minRight = 0;
     maxRight =
-      xPosition(Math.min(...values.map((v) => v.x)), baseScaleData[dataIndex], stackOffset, true)! +
-      mh;
+      xPosition(
+        Math.min(...values.map((v) => v.x)),
+        dataIndex,
+        baseScaleData[dataIndex],
+        stackOffset,
+        true,
+      )! + mh;
     minLeft = 0;
     maxLeft =
-      xPosition(Math.max(...values.map((v) => v.x)), baseScaleData[dataIndex], stackOffset)! + mh;
+      xPosition(
+        Math.max(...values.map((v) => v.x)),
+        dataIndex,
+        baseScaleData[dataIndex],
+        stackOffset,
+      )! + mh;
     center = maxRight - (maxRight - maxLeft) / 2;
     leftCenter = 0;
     rightCenter = 0;
-    middle = yPosition(0, baseScaleData[dataIndex], stackOffset)! - mv;
+    middle = yPosition(0, dataIndex, baseScaleData[dataIndex], stackOffset)! - mv;
     topMiddle =
       yPosition(
         values[0].y - (values[0].y - values[1].y) / 2,
+        dataIndex,
         baseScaleData[dataIndex],
         stackOffset,
       )! - mv;
     bottomMiddle =
       yPosition(
         values[3].y - (values[3].y - values[2].y) / 2,
+        dataIndex,
         baseScaleData[dataIndex],
         stackOffset,
       )! + mv;
   } else {
     minTop = 0;
     maxTop =
-      yPosition(Math.max(...values.map((v) => v.y)), baseScaleData[dataIndex], stackOffset)! - mv;
+      yPosition(
+        Math.max(...values.map((v) => v.y)),
+        dataIndex,
+        baseScaleData[dataIndex],
+        stackOffset,
+      )! - mv;
     minBottom = 0;
     maxBottom =
-      yPosition(Math.min(...values.map((v) => v.y)), baseScaleData[dataIndex], stackOffset, true)! -
-      mv;
-    maxRight = xPosition(values[0].x, baseScaleData[dataIndex], stackOffset)! + mh;
-    minRight = xPosition(values[1].x, baseScaleData[dataIndex], stackOffset)! + mh;
-    minLeft = xPosition(values[2].x, baseScaleData[dataIndex], stackOffset)! - mh;
-    maxLeft = xPosition(values[3].x, baseScaleData[dataIndex], stackOffset)! - mh;
-    center = xPosition(0, baseScaleData[dataIndex], stackOffset)! - mh;
+      yPosition(
+        Math.min(...values.map((v) => v.y)),
+        dataIndex,
+        baseScaleData[dataIndex],
+        stackOffset,
+        true,
+      )! - mv;
+    maxRight = xPosition(values[0].x, dataIndex, baseScaleData[dataIndex], stackOffset)! + mh;
+    minRight = xPosition(values[1].x, dataIndex, baseScaleData[dataIndex], stackOffset)! + mh;
+    minLeft = xPosition(values[2].x, dataIndex, baseScaleData[dataIndex], stackOffset)! - mh;
+    maxLeft = xPosition(values[3].x, dataIndex, baseScaleData[dataIndex], stackOffset)! - mh;
+    center = xPosition(0, dataIndex, baseScaleData[dataIndex], stackOffset)! - mh;
     rightCenter =
       xPosition(
         values[0].x - (values[0].x - values[1].x) / 2,
+        dataIndex,
         baseScaleData[dataIndex],
         stackOffset,
       )! + mh;
     leftCenter =
       xPosition(
         values[3].x - (values[3].x - values[2].x) / 2,
+        dataIndex,
         baseScaleData[dataIndex],
         stackOffset,
       )! - mh;
     middle = yPosition(
       values[0].y - (values[0].y - values[1].y) / 2,
+      dataIndex,
       baseScaleData[dataIndex],
       stackOffset,
     )!;

--- a/packages/x-charts-pro/src/FunnelChart/useFunnelChartProps.ts
+++ b/packages/x-charts-pro/src/FunnelChart/useFunnelChartProps.ts
@@ -168,7 +168,6 @@ export const useFunnelChartProps = (props: FunnelChartProps) => {
   };
 
   const funnelPlotProps: FunnelPlotProps = {
-    gap,
     onItemClick,
     slots,
     slotProps,

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -342,6 +342,7 @@
   { "name": "pinkPaletteDark", "kind": "Variable" },
   { "name": "pinkPaletteLight", "kind": "Variable" },
   { "name": "Position", "kind": "TypeAlias" },
+  { "name": "PositionGetter", "kind": "TypeAlias" },
   { "name": "PropsFromSlot", "kind": "TypeAlias" },
   { "name": "purplePalette", "kind": "Variable" },
   { "name": "purplePaletteDark", "kind": "Variable" },


### PR DESCRIPTION
IMO, curves looks simpler like that.

The solution I went with is:

- For band scale, use the `paddingInner` From that their is nothing to do. Just remove all the hacks
- For the linear scale it's more complex. I ended up with the idea of reducing the range to save some space for the gap.

For example if
- the drawing area let me go from 0px to 200px.
- the funnel has 3 items (so 2 gaps)
- gap is set to 10px

Then, the linear scale will represent values from 0 to 180px. And in getXPosition, If will add 10px  for the second item, and 20 px for the third one.


This idea came when I realised the current implementation is buggy for small items. Look at the 12 % which is flipping over itself

https://github.com/user-attachments/assets/0a6f1539-f03e-480e-a879-7a32db7ec8b2


I also notice the `getXPosition`/`getYPosition` was a bit confusing by having `bandIndex` So I replaced it with `bandIndex` and `bandIdentifier`. The first is effectively the index, and the second is the unique identifier of the band value (the value in `axis.data`